### PR TITLE
Update the C-BIG BIDS importer

### DIFF
--- a/python/import_bids_dataset.py
+++ b/python/import_bids_dataset.py
@@ -39,7 +39,6 @@ def main():
         "\t                         If directory is within $data_dir/assembly_bids, no copy will be performed\n"
         "\t-c, --createcandidate  : to create BIDS candidates in LORIS (optional)\n"
         "\t-s, --createsession    : to create BIDS sessions in LORIS (optional)\n"
-        "\t-i, --idsvalidation    : to validate BIDS directory for a matching pscid/candid pair (optional)\n"
         "\t-b, --nobidsvalidation : to disable BIDS validation for BIDS compliance\n"
         "\t-a, --nocopy           : to disable dataset copy in data assembly_bids\n"
         "\t-t, --type             : raw | derivative. Specify the dataset type.\n"
@@ -56,16 +55,16 @@ def main():
             "value": None, "required": True, "expect_arg": True, "short_opt": "d", "is_path": True
         },
         "createcandidate": {
-            "value": False, "required": False, "expect_arg": False, "short_opt": "cc", "is_path": False
+            "value": False, "required": False, "expect_arg": False, "short_opt": "c", "is_path": False
         },
         "createsession": {
-            "value": False, "required": False, "expect_arg": False, "short_opt": "cc", "is_path": False
+            "value": False, "required": False, "expect_arg": False, "short_opt": "s", "is_path": False
         },
         "nobidsvalidation": {
-            "value": False, "required": False, "expect_arg": False, "short_opt": "nv", "is_path": False
+            "value": False, "required": False, "expect_arg": False, "short_opt": "b", "is_path": False
         },
         "nocopy": {
-            "value": False, "required": False, "expect_arg": False, "short_opt": "nc", "is_path": False
+            "value": False, "required": False, "expect_arg": False, "short_opt": "a", "is_path": False
         },
         "type": {
             "value": None, "required": False, "expect_arg": True, "short_opt": "t", "is_path": False

--- a/python/lib/eeg.py
+++ b/python/lib/eeg.py
@@ -716,7 +716,8 @@ class Eeg:
                 self.bids_layout.root,
                 ""
             )
-            copy_file = self.loris_bids_root_dir + copy_file
+
+            copy_file = os.path.join(self.loris_bids_root_dir, copy_file)
 
             # create derivative directories
             lib.utilities.create_dir(
@@ -738,7 +739,8 @@ class Eeg:
                     "sub-" + self.data_type.subject.label,
                     "sub-" + self.data_type.subject.label + "_ses-" + self.default_vl
                 )
-            copy_file = self.loris_bids_root_dir + copy_file
+
+            copy_file = os.path.join(self.loris_bids_root_dir, copy_file)
 
         # copy the file
         utilities.copy_file(file, copy_file, self.verbose)

--- a/python/lib/import_bids_dataset/check_subjects_sessions.py
+++ b/python/lib/import_bids_dataset/check_subjects_sessions.py
@@ -277,7 +277,10 @@ def create_bids_session(env: Env, candidate: DbCandidate, cohort: DbCohort | Non
     )
 
     session = DbSession(
-        candidate_id     = candidate.id,
+        # C-BIG OVERRIDE START
+        # Remove when upgrading to LORIS 27
+        cand_id          = candidate.cand_id,
+        # C-BIG OVERRIDE END
         visit_label      = visit_label,
         current_stage    = 'Not Started',
         site_id          = candidate.registration_site_id,

--- a/python/lib/import_bids_dataset/check_subjects_sessions.py
+++ b/python/lib/import_bids_dataset/check_subjects_sessions.py
@@ -210,6 +210,8 @@ def create_bids_candidate(env: Env, tsv_participant: BidsTsvParticipant) -> DbCa
         )
     )
 
+    now = datetime.now()
+
     candidate = DbCandidate(
         cand_id                 = cand_id,
         psc_id                  = psc_id,
@@ -217,6 +219,11 @@ def create_bids_candidate(env: Env, tsv_participant: BidsTsvParticipant) -> DbCa
         sex                     = sex,
         registration_site_id    = site.id,
         registration_project_id = project.id,
+        user_id                 = '',
+        entity_type             = 'Human',
+        date_active             = now,
+        date_registered         = now,
+        active                  = True,
     )
 
     env.db.add(candidate)
@@ -264,18 +271,26 @@ def create_bids_session(env: Env, candidate: DbCandidate, cohort: DbCohort | Non
         env,
         (
             "Creating session with:\n"
-            f"  PSCID       = {candidate.cand_id}\n"
+            f"  PSCID       = {candidate.psc_id}\n"
             f"  Visit label = {visit_label}"
         )
     )
 
     session = DbSession(
-        candidate_id  = candidate.id,
-        visit_label   = visit_label,
-        current_stage = 'Not Started',
-        site_id       = candidate.registration_site_id,
-        project_id    = candidate.registration_project_id,
-        cohort_id     = cohort.id,
+        candidate_id     = candidate.id,
+        visit_label      = visit_label,
+        current_stage    = 'Not Started',
+        site_id          = candidate.registration_site_id,
+        project_id       = candidate.registration_project_id,
+        cohort_id        = cohort.id,
+        scan_done        = True,
+        submitted        = False,
+        active           = True,
+        user_id          = '',
+        hardcopy_request = '-',
+        mri_qc_status    = '',
+        mri_qc_pending   = False,
+        mri_caveat       = True,
     )
 
     env.db.add(session)

--- a/python/lib/physiological.py
+++ b/python/lib/physiological.py
@@ -388,7 +388,7 @@ class Physiological:
                 row.get('impedance'),
                 electrode_file
             )
-            
+
             inserted_electrode_id = self.db.insert(
                 table_name   = 'physiological_electrode',
                 column_names = electrode_fields,
@@ -1238,16 +1238,18 @@ class Physiological:
                 # the bids_rel_dir is the first two directories in file_path (
                 # bids_imports/BIDS_dataset_name_BIDSVersion)
                 bids_rel_dir   = file_path.split('/')[0] + '/' + file_path.split('/')[1]
-                chunk_root_dir = data_dir + bids_rel_dir + '_chunks' + '/'
+                chunk_root_dir = os.path.join(data_dir, f'{bids_rel_dir}_chunks')
+
+            full_file_path = os.path.join(data_dir, file_path)
 
             # determine which script to run based on the file type
             file_type = self.grep_file_type_from_file_id(physio_file_id)
             if file_type == 'set':
                 script = os.environ['LORIS_MRI'] + '/python/react-series-data-viewer/eeglab_to_chunks.py'
-                command = 'python ' + script + ' ' + data_dir + file_path + ' --destination ' + chunk_root_dir
+                command = 'python ' + script + ' ' + full_file_path + ' --destination ' + chunk_root_dir
             elif file_type == 'edf':
                 script = os.environ['LORIS_MRI'] + '/python/react-series-data-viewer/edf_to_chunks.py'
-                command = 'python ' + script + ' ' + data_dir + file_path + ' --destination ' + chunk_root_dir
+                command = 'python ' + script + ' ' + full_file_path + ' --destination ' + chunk_root_dir
 
             # chunk the electrophysiology dataset if a command was determined above
             try:


### PR DESCRIPTION
The BIDS importer PR in LORIS-MRI main has started to be reviewed ! And some suggestions have been made. This PR exists to keep the C-BIG version of the importer in sync with the LORIS-MRI main PR one.

The first commit is the port of the following LORIS-MRI main PR commits:
- https://github.com/aces/Loris-MRI/pull/1325/commits/6e25d28ef4db74ad0c4134963e20e3e0e6b414f0 (fix cli options)
- https://github.com/aces/Loris-MRI/pull/1325/commits/b95a6369861adf2e282cb43400ba22136edce7a3 (make profile cli argument optional)
- https://github.com/aces/Loris-MRI/pull/1325/commits/ee2fa8abb252c5bf3e3b3540967907eeb28a5344 (add missing candidate and session fields)
- https://github.com/aces/Loris-MRI/pull/1325/commits/c3f1e4b0eb5d07c9c0ec7845cf4cbd6c56793633 (fix print statement)

The second commit is a forgotten backport.

Note that once the BIDS importer PR will be merged in LORIS-MRI main, I will do a wider and cleaner sync of the LORIS-MRI with C-BIG.